### PR TITLE
django-summernoteを使う

### DIFF
--- a/news_app/forms.py
+++ b/news_app/forms.py
@@ -1,8 +1,24 @@
 from .models import NewsModel
 from django import forms
+from django_summernote.widgets import SummernoteWidget
+from django.conf import settings
+import bleach
+from bleach.css_sanitizer import CSSSanitizer
+
+class HTMLField(forms.CharField):
+    def __init__(self, *args, **kwargs):
+        super(HTMLField, self).__init__(*args, **kwargs)
+        self.widget = SummernoteWidget()
+
+    def to_python(self, value):
+        value = super(HTMLField, self).to_python(value)
+        return bleach.clean(value, tags=settings.ALLOWED_TAGS, attributes=settings.ATTRIBUTES, css_sanitizer=CSSSanitizer())
+
 
 class NewsForm(forms.ModelForm):
     class Meta:
         model = NewsModel
         fields = ('title', 'content', 'author', 'newsimage')
         labels = {'title':'タイトル', 'content':'投稿内容', 'author':'著者', 'newsimage':'表示画像'}
+
+    content = HTMLField()

--- a/science_project/settings.py
+++ b/science_project/settings.py
@@ -32,6 +32,7 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'news_app.apps.NewsAppConfig',
+    'django_summernote',
 ]
 
 MIDDLEWARE = [
@@ -111,3 +112,24 @@ DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 # 画像ファイルの設定
 MEDIA_ROOT = BASE_DIR / 'media'
 MEDIA_URL = 'media_url/'
+
+# summernoteの設定
+SUMMERNOTE_CONFIG = { 
+    'summernote': {
+        'width': '100%',
+        'height': '480',
+    }   
+}
+
+# bleachで判定するHTMLタグと属性の指定
+ALLOWED_TAGS = [ 
+    'a', 'div', 'p', 'span', 'img', 'em', 'i', 'li', 'ol', 'ul', 'strong', 'br',
+    'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
+    'table', 'tbody', 'thead', 'tr', 'td',
+    'abbr', 'acronym', 'b', 'blockquote', 'code', 'strike', 'u', 'sup', 'sub','font'
+]
+ATTRIBUTES = { 
+    '*': ['style', 'align', 'title', 'style' ],
+    'a': ['href', ],
+    'img': ['src', ],
+}

--- a/science_project/urls.py
+++ b/science_project/urls.py
@@ -21,5 +21,6 @@ from django.conf.urls.static import static
 
 urlpatterns = [
     path('', include('news_app.urls')),
+    path('summernote/', include('django_summernote.urls')),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT) \
   + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)

--- a/templates/detail_page.html
+++ b/templates/detail_page.html
@@ -13,7 +13,7 @@
         <p><img src="{{ object.newsimage.url }}" width=300></p>
         <p>タイトル：{{ object.title }}</p>
         <p>投稿者：{{ object.author }}</p>
-        <p>{{ object.content }}</p>
+        <p>{{ object.content|safe }}</p>
     </div>
 </div>
 {% else %}

--- a/templates/top.html
+++ b/templates/top.html
@@ -83,7 +83,7 @@
               </h2>
             </div>
             <div class="box-content">
-              <p>{{ news.content |slice:":70" }}{% if news.content|length > 70 %} ...{% endif %}</p>
+              <p>{{ news.content|safe|striptags|slice:":70" }}{% if news.content|length > 70 %} ...{% endif %}</p>
             </div>
           </div>
         {% endfor %}


### PR DESCRIPTION
# 概要
django-summernoteのテキストエディタが良さそうなので使ってみる。
記事作成時にリッチテキストエディタを使えるようにした。

# 関連issue
#4 