### PR TITLE
GoogleAnalyticsのタグ追加

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -22,6 +22,16 @@
 
     <link href="{% static 'base.css' %}" rel="stylesheet">
 
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-HCQKV8VPQF"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-HCQKV8VPQF');
+    </script>
+
     {% block customcss %}
     {% endblock customcss %}
 


### PR DESCRIPTION
# 概要
Google Analyticsでアクセス数を調べるためタグを追加。

# 関連issue
#58